### PR TITLE
Replace PySide2 dependencies with Qt.py ones

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -427,7 +427,8 @@ setup(
             'urllib3>=1.24.3'
         ],
         'view': [
-            'PySide2~=5.11'
+            'PySide2~=5.11',
+            'Qt.py>=1.1.0'
         ]
     },
 

--- a/src/opentimelineview/console.py
+++ b/src/opentimelineview/console.py
@@ -28,7 +28,7 @@
 import os
 import sys
 import argparse
-from PySide2 import QtWidgets, QtGui
+from Qt import QtWidgets, QtGui
 
 import opentimelineio as otio
 import opentimelineio.console as otio_console
@@ -221,7 +221,7 @@ class Main(QtWidgets.QMainWindow):
 
         def __callback():
             self._navigation_filter_callback(actions)
-        navigation_menu.triggered[[QtWidgets.QAction]].connect(__callback)
+        navigation_menu.triggered[QtWidgets.QAction].connect(__callback)
 
     def _navigation_filter_callback(self, filters):
         nav_filter = 0

--- a/src/opentimelineview/details_widget.py
+++ b/src/opentimelineview/details_widget.py
@@ -22,7 +22,7 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-from PySide2 import QtWidgets, QtGui, QtCore
+from Qt import QtWidgets, QtGui, QtCore
 
 import opentimelineio as otio
 
@@ -33,10 +33,11 @@ class Details(QtWidgets.QTextEdit):
     def __init__(self, *args, **kwargs):
         super(Details, self).__init__(*args, **kwargs)
         self.setReadOnly(True)
-        self.font = QtGui.QFontDatabase.systemFont(
-            QtGui.QFontDatabase.FixedFont)
-        self.font.setPointSize(12)
-        self.setFont(self.font)
+        if hasattr(QtGui.QFontDatabase, 'systemFont'):
+            self.font = QtGui.QFontDatabase.systemFont(
+                QtGui.QFontDatabase.FixedFont)
+            self.font.setPointSize(12)
+            self.setFont(self.font)
 
         self.backgroundColor = QtGui.QColor(33, 33, 33)
         self.textColor = QtGui.QColor(180, 180, 180)

--- a/src/opentimelineview/ruler_widget.py
+++ b/src/opentimelineview/ruler_widget.py
@@ -22,7 +22,7 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-from PySide2 import QtGui, QtCore, QtWidgets
+from Qt import QtGui, QtCore, QtWidgets
 import collections
 import math
 from . import track_widgets
@@ -39,9 +39,7 @@ class FrameNumber(QtWidgets.QGraphicsRectItem):
         self.setBrush(
             QtGui.QBrush(QtGui.QColor(5, 55, 0, 255))
         )
-        self.setPen(
-            QtCore.Qt.NoPen
-        )
+        self.setPen(QtGui.QPen(QtCore.Qt.NoPen))
         self.frameNumber.setBrush(
             QtGui.QBrush(QtGui.QColor(25, 255, 10, 255))
         )

--- a/src/opentimelineview/timeline_widget.py
+++ b/src/opentimelineview/timeline_widget.py
@@ -22,7 +22,7 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-from PySide2 import QtGui, QtCore, QtWidgets
+from Qt import QtGui, QtCore, QtWidgets
 from collections import OrderedDict, namedtuple
 
 import opentimelineio as otio
@@ -418,8 +418,8 @@ def match_filters(item, filters=None):
 
 class CompositionView(QtWidgets.QGraphicsView):
 
-    open_stack = QtCore.Signal(otio.schema.Stack)
-    selection_changed = QtCore.Signal(otio.core.SerializableObject)
+    open_stack = QtCore.Signal(otio.core.SerializableObject)
+    selection_changed = QtCore.Signal(object)
 
     def __init__(self, stack, *args, **kwargs):
         super(CompositionView, self).__init__(*args, **kwargs)
@@ -460,9 +460,9 @@ class CompositionView(QtWidgets.QGraphicsView):
         self.setDragMode(QtWidgets.QGraphicsView.NoDrag)
 
     def wheelEvent(self, event):
-        scale_by = 1.0 + float(event.delta()) / 1000
+        scale_by = 1.0 + float(event.angleDelta().y()) / 1000
         self.scale(scale_by, 1)
-        zoom_level = 1.0 / self.matrix().m11()
+        zoom_level = 1.0 / self.transform().m11()
 
         # some items we do want to keep the same visual size. So we need to
         # inverse the effect of the zoom
@@ -708,10 +708,10 @@ class CompositionView(QtWidgets.QGraphicsView):
             self.frame_all()
 
     def frame_all(self):
-        zoom_level = 1.0 / self.matrix().m11()
+        zoom_level = 1.0 / self.transform().m11()
         scaleFactor = self.size().width() / self.sceneRect().width()
         self.scale(scaleFactor * zoom_level, 1)
-        zoom_level = 1.0 / self.matrix().m11()
+        zoom_level = 1.0 / self.transform().m11()
 
         items_to_scale = [
             i for i in self.scene().items()
@@ -744,7 +744,7 @@ class CompositionView(QtWidgets.QGraphicsView):
 
 class Timeline(QtWidgets.QTabWidget):
 
-    selection_changed = QtCore.Signal(otio.core.SerializableObject)
+    selection_changed = QtCore.Signal(object)
     navigationfilter_changed = QtCore.Signal(int)
 
     def __init__(self, *args, **kwargs):

--- a/src/opentimelineview/track_widgets.py
+++ b/src/opentimelineview/track_widgets.py
@@ -22,7 +22,7 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-from PySide2 import QtGui, QtCore, QtWidgets
+from Qt import QtGui, QtCore, QtWidgets
 import opentimelineio as otio
 
 


### PR DESCRIPTION
Qt.py is abstracting the various implementations of Qt in Python allowing the OpenTimelineIO GUIs to run with PySide2 and PyQt5. Currently, running under PyQt4 and PySide does not produce the expected results.